### PR TITLE
chore: add tsukuba2023 loc map

### DIFF
--- a/ikebe/tsukuba/localization/map_tsukuba_2023.yaml
+++ b/ikebe/tsukuba/localization/map_tsukuba_2023.yaml
@@ -1,0 +1,7 @@
+image: map.pgm
+mode: trinary
+resolution: 0.05
+origin: [-79.8, -127, 0]
+negate: 0
+occupied_thresh: 0.65
+free_thresh: 0.25


### PR DESCRIPTION
* 2023年の地図がアップロードされてなかったのでアップロード
rosbagは[これ](https://www.dropbox.com/scl/fo/588ftwcfzpg9cn8wx1q5e/APB2EwxO6ZFgNjJGN3qxbzY?rlkey=nnv6x8r5ujx2r770lcqxl9s1h&st=lr9ft6fh&dl=0)